### PR TITLE
Ensure Start Setup button visible in Flutter setup GUI

### DIFF
--- a/flutter_env_setup.py
+++ b/flutter_env_setup.py
@@ -62,10 +62,10 @@ class SetupGUI(tk.Tk):
 
     def create_widgets(self) -> None:
         self.text = scrolledtext.ScrolledText(self, state="disabled")
-        self.text.pack(expand=True, fill="both", padx=5, pady=5)
+        self.text.pack(side="top", expand=True, fill="both", padx=5, pady=5)
 
         self.start_button = tk.Button(self, text="Start Setup", command=self.run_setup)
-        self.start_button.pack(pady=5)
+        self.start_button.pack(side="bottom", pady=5)
 
     def log(self, message: str) -> None:
         logging.info(message)


### PR DESCRIPTION
## Summary
- Fix Tkinter layout so "Start Setup" button is anchored at the bottom of the setup window

## Testing
- `python -m py_compile flutter_env_setup.py`
- `python flutter_env_setup.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0450df7208328ba2ba73973fe5387