### PR TITLE
docs: add step-by-step prototype run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,38 +26,72 @@ source .venv/bin/activate
 python flutter_env_setup.py
 ```
 
+## Run the Prototype
+
+After the setup script completes, launch the augmented-reality demo with these steps.
+
+### Linux & Raspberry Pi
+
+1. Activate the virtual environment:
+   ```bash
+   source .venv/bin/activate
+   ```
+2. Enter the Flutter project:
+   ```bash
+   cd mobile_app
+   ```
+3. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+4. Run on the desktop (replace `linux` with a device ID from `flutter devices` if needed):
+   ```bash
+   flutter run -d linux
+   ```
+
+### Windows
+
+1. Activate the virtual environment:
+   ```powershell
+   .\.venv\Scripts\Activate.ps1
+   ```
+2. Enter the Flutter project:
+   ```powershell
+   cd mobile_app
+   ```
+3. Fetch dependencies:
+   ```powershell
+   flutter pub get
+   ```
+4. Run on the desktop (replace `windows` with a device ID from `flutter devices` if needed):
+   ```powershell
+   flutter run -d windows
+   ```
+
+### Android Phones
+
+1. Enable developer mode and USB debugging on the phone.
+2. Connect the phone via USB and verify it appears:
+   ```bash
+   flutter devices
+   ```
+3. Run the app on the phone:
+   ```bash
+   flutter run -d <device-id>
+   ```
+
 ## Manual Setup
+
+If the automated script cannot install Flutter, use these manual commands and then follow **Run the Prototype** above.
 
 ### Linux & Raspberry Pi
 ```bash
 sudo snap install flutter --classic
-cd mobile_app
-flutter pub get
-flutter run -d linux  # or specify connected device
 ```
 
 ### Windows
 ```powershell
 winget install -e --id=Flutter.Flutter
-cd mobile_app
-flutter pub get
-flutter run -d windows # or specify connected device
-```
-
-### Android Device
-Enable developer mode and USB debugging on your phone, then:
-
-#### Linux & Raspberry Pi
-```bash
-cd mobile_app
-./run_android.sh [device-id]
-```
-
-#### Windows
-```powershell
-cd mobile_app
-flutter pub get
-flutter run -d <device-id>
 ```
 
 ### Programmatic Checks


### PR DESCRIPTION
## Summary
- add detailed run instructions for Linux, Windows and Android
- streamline manual setup guidance

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c9cc3688328bd93e55a27d79538